### PR TITLE
Added "UNPLAYABLE" unlockablePlayerState that fixes bypass on my account

### DIFF
--- a/Simple-YouTube-Age-Restriction-Bypass.user.js
+++ b/Simple-YouTube-Age-Restriction-Bypass.user.js
@@ -20,7 +20,7 @@
     var nativeParse = window.JSON.parse; // Backup the original parse function
     var nativeDefineProperty = getNativeDefineProperty(); // Backup the original defineProperty function to intercept setter & getter on the ytInitialPlayerResponse
     var wrappedPlayerResponse = null;
-    var unlockablePlayerStates = ["AGE_VERIFICATION_REQUIRED", "LOGIN_REQUIRED"];
+    var unlockablePlayerStates = ["AGE_VERIFICATION_REQUIRED", "LOGIN_REQUIRED", "UNPLAYABLE"];
     var responseCache = {};
 
     // Just for compatibility: Backup original getter/setter for 'ytInitialPlayerResponse', defined by other extensions like AdBlock


### PR DESCRIPTION
I don't really understand why but when logged in my account, videos have a special "UNPLAYABLE" status. Simply adding it to the unlockablePlayerStates fixed it and allowed me to watch every age restricted videos.