### PR TITLE
Filter out video ads missed by uBlock Origin when Age Restriction Bypass script is enabled

### DIFF
--- a/Simple-YouTube-Age-Restriction-Bypass.user.js
+++ b/Simple-YouTube-Age-Restriction-Bypass.user.js
@@ -84,6 +84,9 @@
             console.error("Simple-YouTube-Age-Restriction-Bypass-Error:", err);
         }
 
+        // Filter out video ads missed by uBlock Origin when Age Restriction Bypass script is enabled
+        if(parsedData.adPlacements) delete(parsedData.adPlacements);
+
         return parsedData;
     }
 


### PR DESCRIPTION
This addresses the race condition between Age Restriction Bypass script and uBlock Origin.

Resolves #6.