### PR TITLE
Fix controversial age-gated videos

### DIFF
--- a/account-proxy/innertube-api.js
+++ b/account-proxy/innertube-api.js
@@ -39,7 +39,9 @@ const generatePlayerRequestData = function (videoId) {
                 "tvAppInfo": {
                     "livingRoomAppMode": "LIVING_ROOM_APP_MODE_UNSPECIFIED"
                 },
-                "clientScreen": "WATCH_FULL_SCREEN"
+                "clientScreen": "WATCH_FULL_SCREEN",
+                "racyCheckOk": true,
+                "contentCheckOk": true,
             },
             "user": {
                 "lockedSafetyMode": false


### PR DESCRIPTION
Based off https://github.com/yt-dlp/yt-dlp/commit/2fd226f6a76715e429709d7172183d48e07c7ab3
This should fix controversial videos returning CONTENT_CHECK_REQUIRED via the proxy, specifically age-gated ones like https://www.youtube.com/watch?v=nGC3D_FkCmg