### PR TITLE
Catch age-gated videos with music embed restrictions for /player bypass

### DIFF
--- a/Simple-YouTube-Age-Restriction-Bypass.user.js
+++ b/Simple-YouTube-Age-Restriction-Bypass.user.js
@@ -226,6 +226,11 @@
                     "embedUrl": "https://www.youtube.com/"
                 }
             },
+            "playbackContext": {
+                "contentPlaybackContext": {
+                    "signatureTimestamp": 18830
+                }
+            },
             "videoId": videoId
         }
     }

--- a/Simple-YouTube-Age-Restriction-Bypass.user.js
+++ b/Simple-YouTube-Age-Restriction-Bypass.user.js
@@ -221,6 +221,9 @@
                     "clientName": "WEB",
                     "clientVersion": "2.20210721.00.00",
                     "clientScreen": "EMBED"
+                },
+                "thirdParty": {
+                    "embedUrl": "https://www.youtube.com/"
                 }
             },
             "videoId": videoId


### PR DESCRIPTION
e.g. https://www.youtube.com/watch?v=HsUATh_Nc2U where the copyrighted music causes the embed to only work when on a public domain
Based off https://stackoverflow.com/a/59640711