### PR TITLE
More age gate playability statuses

### DIFF
--- a/Simple-YouTube-Age-Restriction-Bypass.user.js
+++ b/Simple-YouTube-Age-Restriction-Bypass.user.js
@@ -22,7 +22,7 @@
     var nativeDefineProperty = getNativeDefineProperty(); // Backup the original defineProperty function to intercept setter & getter on the ytInitialPlayerResponse
     var nativeXmlHttpOpen = XMLHttpRequest.prototype.open;
     var wrappedPlayerResponse = null;
-    var unlockablePlayerStates = ["AGE_VERIFICATION_REQUIRED", "LOGIN_REQUIRED"];
+    var unlockablePlayerStates = ["AGE_VERIFICATION_REQUIRED", "AGE_CHECK_REQUIRED", "LOGIN_REQUIRED"];
     var playerResponsePropertyAliases = ["ytInitialPlayerResponse", "playerResponse"];
     var lastProxiedGoogleVideoUrlParams = null;
     var responseCache = {};


### PR DESCRIPTION
Based off reports from korean users on yt-dlp's discord.
P.S. Since the statuses also changes a bit based on region, I think we should detect age-gating via the `desktopLegacyAgeGateReason` property instead (which seems more reliable despite it's name)