### PR TITLE
Restore watch next recommendations for age-gated videos

### DIFF
--- a/Simple-YouTube-Age-Restriction-Bypass.user.js
+++ b/Simple-YouTube-Age-Restriction-Bypass.user.js
@@ -28,6 +28,7 @@
     var nativeDefineProperty = getNativeDefineProperty(); // Backup the original defineProperty function to intercept setter & getter on the ytInitialPlayerResponse
     var nativeXmlHttpOpen = XMLHttpRequest.prototype.open;
     var wrappedPlayerResponse = null;
+    var wrappedNextResponse = null;
     var unlockablePlayerStates = ["AGE_VERIFICATION_REQUIRED", "AGE_CHECK_REQUIRED", "LOGIN_REQUIRED"];
     var playerResponsePropertyAliases = ["ytInitialPlayerResponse", "playerResponse"];
     var lastProxiedGoogleVideoUrlParams = null;
@@ -87,16 +88,16 @@
 
     // Redefine 'ytInitialData' to inspect and modify the initial sidebar response as soon as the variable is set on page load
     nativeDefineProperty(window, "ytInitialData", {
-        set: function (playerResponse) {
+        set: function (nextResponse) {
             // prevent recursive setter calls by ignoring unchanged data (this fixes a problem caused by Brave browser shield)
-            if (playerResponse === wrappedPlayerResponse) return;
+            if (nextResponse === wrappedNextResponse) return;
 
-            wrappedPlayerResponse = inspectJsonData(playerResponse);
-            if (typeof chainedSetter === "function") chainedSetter(wrappedPlayerResponse);
+            wrappedNextResponse = inspectJsonData(nextResponse);
+            if (typeof chainedSetter === "function") chainedSetter(wrappedNextResponse);
         },
         get: function () {
             if (typeof chainedGetter === "function") try { return chainedGetter() } catch (err) { };
-            return wrappedPlayerResponse || {};
+            return wrappedNextResponse || {};
         },
         configurable: true
     });

--- a/Simple-YouTube-Age-Restriction-Bypass.user.js
+++ b/Simple-YouTube-Age-Restriction-Bypass.user.js
@@ -60,8 +60,8 @@
     var chainedPlayerGetter = initialPlayerResponseDescriptor ? initialPlayerResponseDescriptor.get : null;
     // Also back up original getter/setter for 'ytInitialData'
     var initialDataDescriptor = window.Object.getOwnPropertyDescriptor(window, "ytInitialData");
-    var chainedDataSetter = initialPlayerResponseDescriptor ? initialPlayerResponseDescriptor.set : null;
-    var chainedDataGetter = initialPlayerResponseDescriptor ? initialPlayerResponseDescriptor.get : null;
+    var chainedDataSetter = initialDataDescriptor ? initialDataDescriptor.set : null;
+    var chainedDataGetter = initialDataDescriptor ? initialDataDescriptor.get : null;
 
     // Just for compatibility: Intercept (re-)definitions on YouTube's initial player response property to chain setter/getter from other extensions by hijacking the Object.defineProperty function
     window.Object.defineProperty = function (obj, prop, descriptor) {

--- a/Simple-YouTube-Age-Restriction-Bypass.user.js
+++ b/Simple-YouTube-Age-Restriction-Bypass.user.js
@@ -210,11 +210,6 @@
         return parsedData.contents.twoColumnWatchNextResults || parsedData.contents.singleColumnWatchNextResults;
     }
 
-    function isLoggedIn() {
-        setInnertubeConfigFromYtcfg();
-        return innertubeConfig.LOGGED_IN;
-    }
-
     function isWatchNextSidebarEmpty(contents) {
         var secondaryResults = contents.twoColumnWatchNextResults?.secondaryResults?.secondaryResults;
         if (secondaryResults && secondaryResults.results) return false;
@@ -227,6 +222,11 @@
         var itemSectionRenderer = itemSectionRendererArrayItem?.itemSectionRenderer;
 
         return typeof itemSectionRenderer === "undefined";
+    }
+
+    function isLoggedIn() {
+        setInnertubeConfigFromYtcfg();
+        return innertubeConfig.LOGGED_IN;
     }
 
     function unlockPlayerResponse(playerResponse) {
@@ -279,7 +279,7 @@
             nextResponse.contents.twoColumnWatchNextResults.secondaryResults = unlockedNextResponse?.contents?.twoColumnWatchNextResults?.secondaryResults;
         }
 
-        // Mobile
+        // Transfer mobile (MWEB) WatchNextResults to original response
         if (nextResponse.contents?.singleColumnWatchNextResults?.results?.results?.contents) {
             var unlockedWatchNextFeed = unlockedNextResponse?.contents?.singleColumnWatchNextResults?.results?.results?.contents?.find(x => x.itemSectionRenderer?.targetId === "watch-next-feed");
             if (unlockedWatchNextFeed) nextResponse.contents.singleColumnWatchNextResults.results.results.contents.push(unlockedWatchNextFeed);
@@ -365,8 +365,9 @@
         }
 
         // Append client info from INNERTUBE_CONTEXT
-        if (typeof innertubeConfig.INNERTUBE_CONTEXT?.client === "object")
+        if (typeof innertubeConfig.INNERTUBE_CONTEXT?.client === "object") {
             data.context.client = Object.assign(innertubeConfig.INNERTUBE_CONTEXT.client, data.context.client);
+        }
 
         return data;
     }
@@ -380,7 +381,7 @@
 
         for (const key in innertubeConfig) {
             var value = window.ytcfg.data_?.[key] ?? window.ytcfg.get?.(key);
-            if (value) {
+            if (typeof value !== "undefined" && value !== null) {
                 innertubeConfig[key] = value;
             } else {
                 console.warn(`Simple-YouTube-Age-Restriction-Bypass: Unable to retrieve global YouTube configuration variable '${key}'. Using old value...`);

--- a/Simple-YouTube-Age-Restriction-Bypass.user.js
+++ b/Simple-YouTube-Age-Restriction-Bypass.user.js
@@ -152,7 +152,7 @@
 
         // If YouTube does JSON.parse(null) or similar weird things
         if (typeof parsedData !== "object" || parsedData === null) return parsedData;
-        console.info(parsedData)
+
         try {
             // Unlock #1: Array based in "&pbj=1" AJAX response on any navigation (does not seem to be used anymore)
             if (Array.isArray(parsedData)) {

--- a/Simple-YouTube-Age-Restriction-Bypass.user.js
+++ b/Simple-YouTube-Age-Restriction-Bypass.user.js
@@ -215,16 +215,17 @@
 
     function isNextSidebarEmpty(contents) {
         var secondaryResults = contents.twoColumnWatchNextResults?.secondaryResults?.secondaryResults
-        if (secondaryResults && !secondaryResults.results) {
-            return true;
+        if (secondaryResults && secondaryResults.results) {
+            return false;
         }
         // MWEB response layout
         var singleColumnWatchNextContents = contents.singleColumnWatchNextResults?.results?.results?.contents;
-        if (singleColumnWatchNextContents) {
-            var itemSectionRendererArrayItem = singleColumnWatchNextContents.find(e => typeof e.itemSectionRenderer === "object");
-            var itemSectionRenderer = itemSectionRendererArrayItem?.itemSectionRenderer;
-            return (!itemSectionRenderer || !itemSectionRenderer.contents.find(e => typeof e.videoWithContextRenderer === "object"));
+        if (!singleColumnWatchNextContents) {
+            return true;
         }
+        var itemSectionRendererArrayItem = singleColumnWatchNextContents.find(e => e.itemSectionRenderer?.targetId === "watch-next-feed");
+        var itemSectionRenderer = itemSectionRendererArrayItem?.itemSectionRenderer;
+        return typeof itemSectionRenderer === "undefined";
     }
 
     function unlockPlayerResponse(playerResponse) {

--- a/Simple-YouTube-Age-Restriction-Bypass.user.js
+++ b/Simple-YouTube-Age-Restriction-Bypass.user.js
@@ -218,7 +218,7 @@
         if (secondaryResults && secondaryResults.results) {
             return false;
         }
-        // MWEB response layout
+        // Mobile response layout
         var singleColumnWatchNextContents = contents.singleColumnWatchNextResults?.results?.results?.contents;
         if (!singleColumnWatchNextContents) {
             return true;
@@ -236,13 +236,13 @@
         // account proxy error?
         if (unlockedPayerResponse.errorMessage) {
             showPlayerNotification("#7b1e1e", "Unable to unlock this video :( Please look into the developer console for more details. (ProxyError)", 10);
-            throw new Error(`Unlock Failed, errorMessage:${unlockedPayerResponse.errorMessage}; innertubeApiKey:${innertubeConfig.INNERTUBE_API_KEY}; innertubeClientVersion:${innertubeConfig.INNERTUBE_CLIENT_VERSION}`);
+            throw new Error(`Unlock Failed, errorMessage:${unlockedPayerResponse.errorMessage}; innertubeApiKey:${innertubeConfig.INNERTUBE_API_KEY}; innertubeClientName:${innertubeConfig.INNERTUBE_CLIENT_NAME}; innertubeClientVersion:${innertubeConfig.INNERTUBE_CLIENT_VERSION}`);
         }
 
         // check if the unlocked response isn't playable
         if (unlockedPayerResponse.playabilityStatus?.status !== "OK") {
             showPlayerNotification("#7b1e1e", `Unable to unlock this video :( Please look into the developer console for more details. (playabilityStatus: ${unlockedPayerResponse.playabilityStatus?.status})`, 10);
-            throw new Error(`Unlock Failed, playabilityStatus:${unlockedPayerResponse.playabilityStatus?.status}; innertubeApiKey:${innertubeConfig.INNERTUBE_API_KEY}; innertubeClientVersion:${innertubeConfig.INNERTUBE_CLIENT_VERSION}`);
+            throw new Error(`Unlock Failed, playabilityStatus:${unlockedPayerResponse.playabilityStatus?.status}; innertubeApiKey:${innertubeConfig.INNERTUBE_API_KEY}; innertubeClientName:${innertubeConfig.INNERTUBE_CLIENT_NAME}; innertubeClientVersion:${innertubeConfig.INNERTUBE_CLIENT_VERSION}`);
         }
 
         // if the video info was retrieved via proxy, store the URL params from the url- or signatureCipher-attribute to detect later if the requested video files are from this unlock.
@@ -270,7 +270,7 @@
 
         // check if the unlocked response's sidebar is still empty
         if (isNextSidebarEmpty(unlockedNextResponse.contents)) {
-            throw new Error(`Next Unlock Failed, innertubeApiKey:${innertubeConfig.INNERTUBE_API_KEY}; innertubeClientVersion:${innertubeConfig.INNERTUBE_CLIENT_VERSION}`);
+            throw new Error(`Sidebar Unlock Failed, innertubeApiKey:${innertubeConfig.INNERTUBE_API_KEY}; innertubeClientName:${innertubeConfig.INNERTUBE_CLIENT_NAME}; innertubeClientVersion:${innertubeConfig.INNERTUBE_CLIENT_VERSION}`);
         }
 
         return unlockedNextResponse;

--- a/Simple-YouTube-Age-Restriction-Bypass.user.js
+++ b/Simple-YouTube-Age-Restriction-Bypass.user.js
@@ -97,7 +97,7 @@
         configurable: true
     });
 
-    // Redefine 'ytInitialData' to inspect and modify the initial sidebar response as soon as the variable is set on page load
+    // Also redefine 'ytInitialData' for the initial next/sidebar response
     nativeDefineProperty(window, "ytInitialData", {
         set: function (nextResponse) {
             // prevent recursive setter calls by ignoring unchanged data (this fixes a problem caused by Brave browser shield)
@@ -187,6 +187,7 @@
             if (parsedData.playerResponse?.playabilityStatus && parsedData.playerResponse?.videoDetails && isAgeRestricted(parsedData.playerResponse.playabilityStatus)) {
                 parsedData.playerResponse = unlockPlayerResponse(parsedData.playerResponse);
             }
+            // Equivelant of unlock #2 for sidebar/next response
             if (parsedData.response?.currentVideoEndpoint?.watchEndpoint && isNextSidebarEmpty(parsedData.response.contents)) {
                 parsedData.response = unlockNextResponse(parsedData.response);
             }
@@ -195,6 +196,7 @@
             if (parsedData.playabilityStatus && parsedData.videoDetails && isAgeRestricted(parsedData.playabilityStatus)) {
                 parsedData = unlockPlayerResponse(parsedData);
             }
+            // Equivelant of unlock #3 for sidebar/next response
             if (parsedData.currentVideoEndpoint?.watchEndpoint && isNextSidebarEmpty(parsedData.contents)) {
                 parsedData = unlockNextResponse(parsedData)
             }
@@ -265,8 +267,8 @@
         var playlistIndex = watchEndpoint.index;
         var unlockedNextResponse = getUnlockedNextResponse(videoId, playlistId, playlistIndex);
 
-        // check if the unlocked response isn't playable
-        if (!isNextSidebarEmpty(unlockedNextResponse.contents)) {
+        // check if the unlocked response's sidebar is still empty
+        if (isNextSidebarEmpty(unlockedNextResponse.contents)) {
             throw new Error(`Next Unlock Failed, innertubeApiKey:${innertubeConfig.INNERTUBE_API_KEY}; innertubeClientVersion:${innertubeConfig.INNERTUBE_CLIENT_VERSION}`);
         }
 
@@ -323,7 +325,7 @@
         // Retrieve the video info by using a age-gate bypass for the innertube API
         // Source: https://github.com/zerodytrash/Simple-YouTube-Age-Restriction-Bypass/issues/16#issuecomment-889232425
         function useInnertubeEmbed() {
-            console.info("Simple-YouTube-Age-Restriction-Bypass: Trying Sidebar Unlock Method #1 (Innertube Embed)");
+            console.info("Simple-YouTube-Age-Restriction-Bypass: Trying Sidebar Unlock Method (Innertube Embed)");
             var payload = getInnertubeEmbedPlayerPayload(videoId, playlistId, playlistIndex);
             var xmlhttp = new XMLHttpRequest();
             xmlhttp.open("POST", `/youtubei/v1/next?key=${innertubeConfig.INNERTUBE_API_KEY}`, false); // Synchronous!!!

--- a/Simple-YouTube-Age-Restriction-Bypass.user.js
+++ b/Simple-YouTube-Age-Restriction-Bypass.user.js
@@ -279,8 +279,10 @@
             nextResponse.contents.twoColumnWatchNextResults.secondaryResults = unlockedNextResponse?.contents?.twoColumnWatchNextResults?.secondaryResults;
         }
 
-        if (nextResponse.contents?.singleColumnWatchNextResults) {
-            nextResponse.contents.singleColumnWatchNextResults = unlockedNextResponse?.contents?.singleColumnWatchNextResults;
+        // Mobile
+        if (nextResponse.contents?.singleColumnWatchNextResults?.results?.results?.contents) {
+            var unlockedWatchNextFeed = unlockedNextResponse?.contents?.singleColumnWatchNextResults?.results?.results?.contents?.find(x => x.itemSectionRenderer?.targetId === "watch-next-feed");
+            if (unlockedWatchNextFeed) nextResponse.contents.singleColumnWatchNextResults.results.results.contents.push(unlockedWatchNextFeed);
         }
 
         return nextResponse;

--- a/Simple-YouTube-Age-Restriction-Bypass.user.js
+++ b/Simple-YouTube-Age-Restriction-Bypass.user.js
@@ -88,10 +88,10 @@
             if (playerResponse === wrappedPlayerResponse) return;
 
             wrappedPlayerResponse = inspectJsonData(playerResponse);
-            if (typeof chainedPlayerSetter === "function") chainedDataSetter(wrappedPlayerResponse);
+            if (typeof chainedPlayerSetter === "function") chainedPlayerSetter(wrappedPlayerResponse);
         },
         get: function () {
-            if (typeof chainedPlayerGetter === "function") try { return chainedGetter() } catch (err) { };
+            if (typeof chainedPlayerGetter === "function") try { return chainedPlayerGetter() } catch (err) { };
             return wrappedPlayerResponse || {};
         },
         configurable: true
@@ -107,7 +107,7 @@
             if (typeof chainedDataSetter === "function") chainedDataSetter(wrappedNextResponse);
         },
         get: function () {
-            if (typeof chainedDataGetter === "function") try { return chainedGetter() } catch (err) { };
+            if (typeof chainedDataGetter === "function") try { return chainedDataGetter() } catch (err) { };
             return wrappedNextResponse || {};
         },
         configurable: true

--- a/Simple-YouTube-Age-Restriction-Bypass.user.js
+++ b/Simple-YouTube-Age-Restriction-Bypass.user.js
@@ -254,7 +254,7 @@
         var unlockedNextResponse = getUnlockedNextResponse(videoId, playlistId, playlistIndex);
 
         // check if the unlocked response isn't playable
-        if (!isNextSidebarEmpty(unlockNextResponse.contents)) {
+        if (!isNextSidebarEmpty(unlockedNextResponse.contents)) {
             throw new Error(`Next Unlock Failed, innertubeApiKey:${innertubeConfig.INNERTUBE_API_KEY}; innertubeClientVersion:${innertubeConfig.INNERTUBE_CLIENT_VERSION}`);
         }
 

--- a/Simple-YouTube-Age-Restriction-Bypass.user.js
+++ b/Simple-YouTube-Age-Restriction-Bypass.user.js
@@ -274,7 +274,16 @@
             throw new Error(`Sidebar Unlock Failed, innertubeApiKey:${innertubeConfig.INNERTUBE_API_KEY}; innertubeClientName:${innertubeConfig.INNERTUBE_CLIENT_NAME}; innertubeClientVersion:${innertubeConfig.INNERTUBE_CLIENT_VERSION}`);
         }
 
-        return unlockedNextResponse;
+        // Transfer WatchNextResults to original response
+        if (nextResponse.contents?.twoColumnWatchNextResults?.secondaryResults) {
+            nextResponse.contents.twoColumnWatchNextResults.secondaryResults = unlockedNextResponse?.contents?.twoColumnWatchNextResults?.secondaryResults;
+        }
+
+        if (nextResponse.contents?.singleColumnWatchNextResults) {
+            nextResponse.contents.singleColumnWatchNextResults = unlockedNextResponse?.contents?.singleColumnWatchNextResults;
+        }
+
+        return nextResponse;
     }
 
     function getUnlockedPlayerResponse(videoId, reason) {

--- a/Simple-YouTube-Age-Restriction-Bypass.user.js
+++ b/Simple-YouTube-Age-Restriction-Bypass.user.js
@@ -341,7 +341,7 @@
         return {
             "context": {
                 "client": {
-                    "clientName": innertubeConfig.INNERTUBE_CLIENT_NAME,
+                    "clientName": innertubeConfig.INNERTUBE_CLIENT_NAME.replace('_EMBEDDED_PLAYER', ''),
                     "clientVersion": innertubeConfig.INNERTUBE_CLIENT_VERSION,
                     "clientScreen": "EMBED"
                 },


### PR DESCRIPTION
Closes #16 
TODOs:
- [x] Add /next bypass for age-gated videos
- [x] Pass playlist parameters to /next
- [x] Fix `ytInitialData` interception
- [x] Use /next bypass for m.youtube.com
- [x] Fix "Comment is disabled" on unembeddable videos (https://youtu.be/Cr381pDsSsA, comment works when not using embed bypass so we probably don't need a /next proxy)
- [x] Test for unexpected bugs