### PR TITLE
Fix misplaced comments by Babel

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,4 @@
 export default {
-    presets: [['@babel/preset-env', { "modules": false }]],
+    presets: [ ['@babel/preset-env', { modules: false }] ],
+    retainLines: true,
 }


### PR DESCRIPTION
This has a side-effect of adding some whitespaces/newlines in the output