### PR TITLE
fix potential bug with `clientConfig`

### DIFF
--- a/src/components/innertubeClient.js
+++ b/src/components/innertubeClient.js
@@ -31,12 +31,12 @@ function sendInnertubeRequest(endpoint, payload, useAuth) {
     return nativeJSONParse(xmlhttp.responseText);
 }
 
-function getInnertubeEmbedPayload(videoId, clientConfig, playlistId, playlistIndex) {
+function getInnertubeEmbedPayload(videoId, clientConfig = {}, playlistId, playlistIndex) {
     const payload = {
         context: {
             client: {
                 ...getYtcfgValue('INNERTUBE_CONTEXT').client,
-                ...clientConfig || {}
+                ...clientConfig
             },
             thirdParty: {
                 embedUrl: "https://www.youtube.com/",


### PR DESCRIPTION
If `clientConfig` is not provided, this could result in an exception.

The `|| {}` does not help because it gets spread first before the 'OR' and
would probably result in an exception.

Possible solutions:
- Surround with parentheses (`...(clientConfig || {})`)
- Provide default function parameter

I choose the second in this case.