### PR TITLE
[fix] improve extension compatibility

### DIFF
--- a/src/components/interceptor.js
+++ b/src/components/interceptor.js
@@ -11,18 +11,18 @@ function interceptProp(obj, prop, { setter }) {
         set: (value) => {
             // prettier-ignore
             // eslint-disable-next-line no-empty
-            if (set) try { set(value) } catch (err) { }
+            if (set) try { set.call(obj, value) } catch (err) { }
 
-            // prevent recursive setter calls by ignoring unchanged data (this fixes a problem caused by Brave browser shield)
+            // prevent recursive setter calls by ignoring unchanged object reference
             if (value === prevValue) return;
 
-            setter?.(value);
+            setter?.call(obj, value);
             prevValue = value;
         },
         get: () => {
             // prettier-ignore
             // eslint-disable-next-line no-empty
-            if (get) try { return get() } catch (err) { }
+            if (get) try { return get.call(obj) } catch (err) { }
             return prevValue || {};
         },
         configurable: true,

--- a/src/components/interceptor.js
+++ b/src/components/interceptor.js
@@ -9,16 +9,18 @@ function interceptProp(obj, prop, { setter }) {
 
     Object.defineProperty(obj, prop, {
         set: (value) => {
+            // prettier-ignore
+            // eslint-disable-next-line no-empty
+            if (set) try { set(prevValue) } catch (err) { }
+
             // prevent recursive setter calls by ignoring unchanged data (this fixes a problem caused by Brave browser shield)
             if (value === prevValue) return;
 
             setter?.(value);
             prevValue = value;
-
-            // eslint-disable-next-line no-empty
-            if (set) try { set(prevValue) } catch (err) { }
         },
         get: () => {
+            // prettier-ignore
             // eslint-disable-next-line no-empty
             if (get) try { return get() } catch (err) { }
             return prevValue || {};

--- a/src/components/interceptor.js
+++ b/src/components/interceptor.js
@@ -11,7 +11,7 @@ function interceptProp(obj, prop, { setter }) {
         set: (value) => {
             // prettier-ignore
             // eslint-disable-next-line no-empty
-            if (set) try { set(prevValue) } catch (err) { }
+            if (set) try { set(value) } catch (err) { }
 
             // prevent recursive setter calls by ignoring unchanged data (this fixes a problem caused by Brave browser shield)
             if (value === prevValue) return;

--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,5 @@
 // Script configuration variables
 export const UNLOCKABLE_PLAYER_STATES = ['AGE_VERIFICATION_REQUIRED', 'AGE_CHECK_REQUIRED', 'LOGIN_REQUIRED'];
-export const PLAYER_RESPONSE_ALIASES = ['ytInitialPlayerResponse', 'playerResponse'];
 
 // Show notification?
 export const ENABLE_UNLOCK_NOTIFICATION = true;

--- a/src/main.js
+++ b/src/main.js
@@ -10,6 +10,9 @@ interceptor.attachJsonInterceptor(checkAndUnlock);
 interceptor.attachXhrOpenInterceptor(onXhrOpenCalled);
 
 function checkAndUnlock(ytData) {
+
+    if (!ytData) return;
+
     try {
         // Unlock #1: Initial page data structure and response from the '/youtubei/v1/player' endpoint
         if (inspector.isPlayerObject(ytData) && inspector.isAgeRestricted(ytData.playabilityStatus)) {

--- a/src/utils/natives.js
+++ b/src/utils/natives.js
@@ -1,25 +1,3 @@
-import { createElement } from '../utils';
-
 export const nativeJSONParse = window.JSON.parse;
 
 export const nativeXMLHttpRequestOpen = XMLHttpRequest.prototype.open;
-
-// Some extensions like AdBlock override the Object.defineProperty function to prevent a redefinition of the 'ytInitialPlayerResponse' variable by YouTube.
-// But we need to define a custom descriptor to that variable to intercept its value. This behavior causes a race condition depending on the execution order with this script :(
-// To solve this problem the native defineProperty function will be retrieved from another window (iframe)
-export const nativeObjectDefineProperty = (() => {
-    // Check if function is native
-    if (Object.defineProperty.toString().includes('[native code]')) {
-        return Object.defineProperty;
-    }
-
-    // If function is overidden, restore the native function from another window...
-    const tempFrame = createElement('iframe', { style: `display: none;` });
-    document.documentElement.append(tempFrame);
-
-    const native = tempFrame.contentWindow.Object.defineProperty;
-
-    tempFrame.remove();
-
-    return native;
-})();


### PR DESCRIPTION
Fixes #83?

The `Object.defineProperty` override is not needed and only does harm, so remove it and also do some cleanup.

This override is supposed to make our userscript more compatible with other extensions redefining properties that we use, but actually does the opposite. We backup the getter and setter of a prop if it is defined by other extensions, we then replace the getter and setter of the prop with our own. To make it compatible with the other extension we call the getter and setter that we backed up, after we have finished doing things on our side. But then the real issue begins when we override `Object.defineProperty` and intercept the other extensions trying to redefine the prop getter and setter by replacing those with the ones we backed up earlier, thus trading compatibility with the extension that has run before us with the one that ran after.

Obviously that is not what we want. A proper chain starts with us storing the previous getter and setter and calling those when we finish doing our work. The next extension that is trying to define their getter and setter should do the same thing, creating a chain.

A proper chain would look something like this in a callstack.

**Before:**
- Extension A is detached.
- C is calling B while B is calling C. (potential loop)
```
A             B - us           C
[get, set]    [get, set] -> <- [get, set]
```
**After:**
- All extensions call the extension that has ran before them, creating a proper chain.
```
A             B - us        C
[get, set] <- [get, set] <- [get, set]
```