### PR TITLE
[chore] add CI & make some additional changes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 # Auto detect text files and perform LF normalization
-* text=auto
+* text=auto eol=lf

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,21 @@
+name: Build
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Setup NodeJS
+        uses: actions/setup-node@v2
+        with:
+          node-version: 'lts/*'
+
+      - name: Checkout master
+        uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Check format
+        run: npm run check-format

--- a/.prettierrc.cjs
+++ b/.prettierrc.cjs
@@ -1,5 +1,4 @@
 module.exports = {
-    trailingComma: "none",
     singleQuote: true,
     printWidth: 180
 };

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "homepage": "https://github.com/zerodytrash/Simple-YouTube-Age-Restriction-Bypass#readme",
   "scripts": {
     "build": "rollup -c",
-    "format": "prettier -w src/**/*.js"
+    "format": "prettier --write src/**/*.js",
+    "check-format": "prettier --check src/**/*.js"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.16.4",

--- a/src/components/innertubeClient.js
+++ b/src/components/innertubeClient.js
@@ -76,20 +76,20 @@ function getInnertubeEmbedPayload(videoId, clientConfig, playlistId, playlistInd
             client: {
                 ...getYtcfgValue('INNERTUBE_CONTEXT').client,
                 ...{ clientName: getMainPageClientName() },
-                ...(clientConfig || {})
+                ...(clientConfig || {}),
             },
             thirdParty: {
-                embedUrl: 'https://www.youtube.com/'
-            }
+                embedUrl: 'https://www.youtube.com/',
+            },
         },
         playbackContext: {
             contentPlaybackContext: {
-                signatureTimestamp: getSignatureTimestamp()
-            }
+                signatureTimestamp: getSignatureTimestamp(),
+            },
         },
         videoId,
         playlistId,
-        playlistIndex
+        playlistIndex,
     };
 }
 

--- a/src/components/interceptor.js
+++ b/src/components/interceptor.js
@@ -39,7 +39,7 @@ export function attachInitialDataInterceptor(onInititalDataSet) {
                 }
             return wrappedPlayerResponse || {};
         },
-        configurable: true
+        configurable: true,
     });
 
     // Also redefine 'ytInitialData' for the initial next/sidebar response
@@ -48,7 +48,7 @@ export function attachInitialDataInterceptor(onInititalDataSet) {
             wrappedNextResponse = isObject(nextResponse) ? onInititalDataSet(nextResponse) : nextResponse;
         },
         get: () => wrappedNextResponse,
-        configurable: true
+        configurable: true,
     });
 }
 

--- a/src/components/toast/index.js
+++ b/src/components/toast/index.js
@@ -11,16 +11,16 @@ const nToast = nToastContainer.querySelector(':scope > *');
 
 document.documentElement.append(nToastContainer);
 
-!isDesktop && (
-    nToast.nMessage = nToast.querySelector('.notification-action-response-text'),
+if (!isDesktop) {
+    nToast.nMessage = nToast.querySelector('.notification-action-response-text');
     nToast.show = (message) => {
         nToast.nMessage.innerText = message;
         nToast.setAttribute('dir', 'in');
         setTimeout(() => {
             nToast.setAttribute('dir', 'out');
         }, nToast.duration + 225);
-    }
-);
+    };
+}
 
 async function show(message, duration = 5) {
     if (!Config.ENABLE_UNLOCK_NOTIFICATION) return;

--- a/src/components/unlocker.js
+++ b/src/components/unlocker.js
@@ -7,7 +7,7 @@ import { isDesktop, isEmbed } from '../utils';
 
 const messagesMap = {
     success: 'Age-restricted video successfully unlocked!',
-    fail: 'Unable to unlock this video 🙁 - More information in the developer console'
+    fail: 'Unable to unlock this video 🙁 - More information in the developer console',
 };
 
 let lastProxiedGoogleVideoUrlParams;

--- a/src/components/unlocker.js
+++ b/src/components/unlocker.js
@@ -83,7 +83,7 @@ function getUnlockStrategies(playerResponse) {
                 isEmbed: +isEmbed,
             },
             getPlayer: proxy.getPlayer,
-        }
+        },
     ];
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -54,7 +54,7 @@ function onXhrOpenCalled(xhr, method, url) {
         // solve CORS errors by preventing YouTube from enabling the "withCredentials" option (required for the proxy)
         Object.defineProperty(xhr, 'withCredentials', {
             set: () => {},
-            get: () => false
+            get: () => false,
         });
 
         return proxy.getGoogleVideoUrl(url.toString(), Config.VIDEO_PROXY_SERVER_HOST);

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -152,14 +152,16 @@ export let pageLoadedAndVisible = (() => {
     const pageLoadEventName = isDesktop ? 'yt-navigate-finish' : 'state-navigateend';
 
     window.addEventListener(pageLoadEventName, () => {
-        document.visibilityState === 'hidden'
-            ? document.addEventListener('visibilitychange', ready, { once: true })
-            : ready();
+        if (document.visibilityState === 'hidden') {
+            document.addEventListener('visibilitychange', ready, { once: true });
+        } else {
+            ready();
+        }
     });
 
     function ready() {
         pageLoadedAndVisible.resolve();
-        pageLoadedAndVisible = new Deferred;
+        pageLoadedAndVisible = new Deferred();
     }
 
     return new Deferred();


### PR DESCRIPTION
CI currently only checks if the code is correctly formatted, or else it fails with a clear message and the PR owner has to run `npm run format`. This CI runs on each push and pull request, additionally it can be ran manually by the repo owner.

Additional changes:
- Formatted files
- Removed `trailingComma: "none"` from Prettier config
- Added `eol=lf` to `.gitattributes` to force eol formats