### PR TITLE
Decorate `interceptObject`'s target

### DIFF
--- a/src/components/interceptor.js
+++ b/src/components/interceptor.js
@@ -3,12 +3,9 @@ import { nativeJSONParse, nativeXMLHttpRequestOpen } from '../utils/natives';
 import * as logger from '../utils/logger';
 
 function interceptObject(proto, prop, onSet) {
-    const symbol = Symbol.for('SYARB' + prop);
     // Allow other userscripts to decorate this descriptor, if they do something similar to this as well
-    const {
-        get: getter,
-        set: setter,
-    } = Object.getOwnPropertyDescriptor(proto, prop) ?? {
+    const symbol = Symbol.for('SYARB' + prop);
+    const { get: getter, set: setter } = Object.getOwnPropertyDescriptor(proto, prop) ?? {
         set(value) {
             this[symbol] = value;
         },
@@ -16,6 +13,7 @@ function interceptObject(proto, prop, onSet) {
             return this[symbol];
         },
     };
+
     Object.defineProperty(proto, prop, {
         set(value) {
             setter.call(this, isObject(value) ? onSet(this, value) : value);


### PR DESCRIPTION
This allows other userscripts to interoperate with this one, or any other for that matter.

A particular property that would benefit from this decorating is "playerResponse", which contains loads of knobs that can be turned by other userscripts as well.

An example I have for how another userscript could do its work with this is like so:

```js
// Interop with "Simple YouTube Age Restriction Bypass"
const {
  get: getter,
  set: setter,
} = Object.getOwnPropertyDescriptor(Object.prototype, "playerResponse") ?? {
  set(value) {
    this[Symbol.for("YTBetter")] = value;
  },
  get() {
    return this[Symbol.for("YTBetter")];
  },
};

const isObject = (value) => value != null && typeof value === "object";

Object.defineProperty(Object.prototype, "playerResponse", {
  set(value) {
    if (isObject(value)) {
      const { videoDetails } = value;
      if (isObject(videoDetails)) {
        /* magic */
      }
    }
    setter.call(this, value);
  },
  get() {
    return getter.call(this);
  },
  configurable: true,
});
```

I have the above in use right now with this PR applied to my copy of `Simple-YouTube-Age-Restriction-Bypass` as well.