### PR TITLE
Simple fixes for increasing compatibility with different browsers

### DIFF
--- a/src/components/interceptors/generic.js
+++ b/src/components/interceptors/generic.js
@@ -8,7 +8,7 @@ export default function attach(obj, prop, onCall) {
     obj[prop] = function () {
         try {
             onCall(arguments);
-        } catch {}
+        } catch (err) {}
         original.apply(this, arguments);
     };
 }

--- a/src/components/interceptors/request.js
+++ b/src/components/interceptors/request.js
@@ -20,7 +20,7 @@ export default function attach(onRequestCreate) {
                 logger.error(err, `Failed to intercept Request()`);
             }
 
-            return Reflect.construct(...arguments);
+            return Reflect.construct(target, args);
         },
     });
 }

--- a/src/components/requestPreprocessor.js
+++ b/src/components/requestPreprocessor.js
@@ -100,6 +100,6 @@ function setContentCheckOk(bodyJson) {
             parsedBody.racyCheckOk = true;
             return JSON.stringify(parsedBody);
         }
-    } catch {}
+    } catch (err) {}
     return bodyJson;
 }

--- a/src/components/storage.js
+++ b/src/components/storage.js
@@ -7,7 +7,7 @@ export function set(key, value) {
 export function get(key) {
     try {
         return JSON.parse(localStorage.getItem(localStoragePrefix + key));
-    } catch {
+    } catch (err) {
         return null;
     }
 }

--- a/src/components/unlocker/next.js
+++ b/src/components/unlocker/next.js
@@ -53,7 +53,7 @@ function getUnlockedNextResponse(videoId) {
     });
 
     // Cache response to prevent a flood of requests in case youtube processes a blocked response mutiple times.
-    cachedNextResponse = { videoId, ...createDeepCopy(unlockedNextResponse) };
+    cachedNextResponse = Object.assign({"videoId": videoId}, createDeepCopy(unlockedNextResponse));
 
     return unlockedNextResponse;
 }

--- a/src/components/unlocker/player.js
+++ b/src/components/unlocker/player.js
@@ -99,7 +99,7 @@ function getUnlockedPlayerResponse(videoId, reason) {
     });
 
     // Cache response to prevent a flood of requests in case youtube processes a blocked response mutiple times.
-    cachedPlayerResponse = { videoId, ...createDeepCopy(unlockedPlayerResponse) };
+    cachedPlayerResponse = Object.assign({"videoId": videoId}, createDeepCopy(unlockedPlayerResponse));
 
     return unlockedPlayerResponse;
 }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -38,7 +38,7 @@ export function findNestedObjectsByAttributeNames(object, attributeNames) {
     // Diggin' deeper for each nested object (recursive)
     Object.keys(object).forEach((key) => {
         if (object[key] && typeof object[key] === 'object') {
-            results.push(...findNestedObjectsByAttributeNames(object[key], attributeNames));
+            results = results.concat(findNestedObjectsByAttributeNames(object[key], attributeNames));
         }
     });
 
@@ -154,7 +154,7 @@ export function parseRelativeUrl(url) {
 
     try {
         return url.indexOf('https://') === 0 ? new window.URL(url) : null;
-    } catch {
+    } catch (err) {
         return null;
     }
 }


### PR DESCRIPTION
Mostly this is just a trivial replacement of `catch { ... }` with `catch (err) { ... }`, but also all operators where spread syntax is used are replaced by their conventional equivalents.