### PR TITLE
[chore] replace Prettier with dprint

### DIFF
--- a/.prettierrc.cjs
+++ b/.prettierrc.cjs
@@ -1,4 +1,0 @@
-module.exports = {
-    singleQuote: true,
-    printWidth: 180
-};

--- a/dprint.json
+++ b/dprint.json
@@ -1,0 +1,10 @@
+{
+  "typescript": {
+    "lineWidth": 180,
+    "indentWidth": 4,
+    "quoteStyle": "preferSingle"
+  },
+  "plugins": [
+    "https://plugins.dprint.dev/typescript-0.74.0.wasm"
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@rollup/plugin-node-resolve": "^14.1.0",
         "@rollup/plugin-replace": "^4.0.0",
         "archiver": "^5.3.1",
-        "prettier": "^2.7.1",
+        "dprint": "^0.32.1",
         "rollup": "^2.79.1",
         "rollup-plugin-html": "^0.2.1"
       }
@@ -2262,6 +2262,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/dprint": {
+      "version": "0.32.1",
+      "resolved": "https://registry.npmjs.org/dprint/-/dprint-0.32.1.tgz",
+      "integrity": "sha512-HBG9npq+26QW1IjhLyMfX0qMwkIYREZqMByNmLL9O778rsyK54eTkXPhuIBeF1FA2VIoZg3t/5si6FRvDtoQmw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "yauzl": "=2.10.0"
+      },
+      "bin": {
+        "dprint": "bin.js"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.4.271",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.271.tgz",
@@ -2317,6 +2330,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "dependencies": {
+        "pend": "~1.2.0"
       }
     },
     "node_modules/fs-constants": {
@@ -2789,6 +2811,12 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true
+    },
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -2805,21 +2833,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
-      "dev": true,
-      "bin": {
-        "prettier": "bin-prettier.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/printj": {
@@ -3204,6 +3217,16 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
     },
     "node_modules/zip-stream": {
       "version": "4.1.0",
@@ -4812,6 +4835,15 @@
         "object-keys": "^1.1.1"
       }
     },
+    "dprint": {
+      "version": "0.32.1",
+      "resolved": "https://registry.npmjs.org/dprint/-/dprint-0.32.1.tgz",
+      "integrity": "sha512-HBG9npq+26QW1IjhLyMfX0qMwkIYREZqMByNmLL9O778rsyK54eTkXPhuIBeF1FA2VIoZg3t/5si6FRvDtoQmw==",
+      "dev": true,
+      "requires": {
+        "yauzl": "=2.10.0"
+      }
+    },
     "electron-to-chromium": {
       "version": "1.4.271",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.271.tgz",
@@ -4856,6 +4888,15 @@
       "resolved": "https://registry.npmjs.org/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz",
       "integrity": "sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw==",
       "dev": true
+    },
+    "fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "requires": {
+        "pend": "~1.2.0"
+      }
     },
     "fs-constants": {
       "version": "1.0.0",
@@ -5227,6 +5268,12 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
+    "pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true
+    },
     "picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -5237,12 +5284,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
       "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
-      "dev": true
-    },
-    "prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
       "dev": true
     },
     "printj": {
@@ -5539,6 +5580,16 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
+    },
+    "yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "requires": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
     },
     "zip-stream": {
       "version": "4.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@rollup/plugin-node-resolve": "^14.1.0",
         "@rollup/plugin-replace": "^4.0.0",
         "archiver": "^5.3.1",
-        "dprint": "^0.32.1",
+        "dprint": "^0.32.2",
         "rollup": "^2.79.1",
         "rollup-plugin-html": "^0.2.1"
       }
@@ -2263,9 +2263,9 @@
       }
     },
     "node_modules/dprint": {
-      "version": "0.32.1",
-      "resolved": "https://registry.npmjs.org/dprint/-/dprint-0.32.1.tgz",
-      "integrity": "sha512-HBG9npq+26QW1IjhLyMfX0qMwkIYREZqMByNmLL9O778rsyK54eTkXPhuIBeF1FA2VIoZg3t/5si6FRvDtoQmw==",
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/dprint/-/dprint-0.32.2.tgz",
+      "integrity": "sha512-cGKnZonCFQkcNbptAtJXlzUOqyiyYoD9pINepJ9PvkFi8iwMLChQDSjhMeqT3DDQf5Rof3pYA5LI/bafPpPknQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -4836,9 +4836,9 @@
       }
     },
     "dprint": {
-      "version": "0.32.1",
-      "resolved": "https://registry.npmjs.org/dprint/-/dprint-0.32.1.tgz",
-      "integrity": "sha512-HBG9npq+26QW1IjhLyMfX0qMwkIYREZqMByNmLL9O778rsyK54eTkXPhuIBeF1FA2VIoZg3t/5si6FRvDtoQmw==",
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/dprint/-/dprint-0.32.2.tgz",
+      "integrity": "sha512-cGKnZonCFQkcNbptAtJXlzUOqyiyYoD9pINepJ9PvkFi8iwMLChQDSjhMeqT3DDQf5Rof3pYA5LI/bafPpPknQ==",
       "dev": true,
       "requires": {
         "yauzl": "=2.10.0"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@rollup/plugin-node-resolve": "^14.1.0",
     "@rollup/plugin-replace": "^4.0.0",
     "archiver": "^5.3.1",
-    "dprint": "^0.32.1",
+    "dprint": "^0.32.2",
     "rollup": "^2.79.1",
     "rollup-plugin-html": "^0.2.1"
   }

--- a/package.json
+++ b/package.json
@@ -18,11 +18,11 @@
     "dist/Simple-YouTube-Age-Restriction-Bypass.user.js"
   ],
   "scripts": {
-    "build": "npm run clean && rollup -c && prettier --write dist/*.user.js && npm run archive-extension",
+    "build": "npm run clean && rollup -c && dprint fmt dist/*.user.js && npm run archive-extension",
     "clean": "node scripts/clean.js",
     "archive-extension": "node scripts/archive-extension.js",
-    "format": "prettier --write src/**/*.js",
-    "check-format": "prettier --check src/**/*.js"
+    "format": "dprint fmt src/**/*.js",
+    "check-format": "dprint check src/**/*.js"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.19.3",
@@ -31,7 +31,7 @@
     "@rollup/plugin-node-resolve": "^14.1.0",
     "@rollup/plugin-replace": "^4.0.0",
     "archiver": "^5.3.1",
-    "prettier": "^2.7.1",
+    "dprint": "^0.32.1",
     "rollup": "^2.79.1",
     "rollup-plugin-html": "^0.2.1"
   }

--- a/src/components/confirmation.js
+++ b/src/components/confirmation.js
@@ -1,6 +1,6 @@
-import { isEmbed, isConfirmed, setUrlParams } from '../utils';
-import { addButton, removeButton } from './errorScreen';
 import Config from '../config';
+import { isConfirmed, isEmbed, setUrlParams } from '../utils';
+import { addButton, removeButton } from './errorScreen';
 
 const confirmationButtonId = 'confirmButton';
 const confirmationButtonText = 'Click to unlock';

--- a/src/components/endpoints/innertube.js
+++ b/src/components/endpoints/innertube.js
@@ -1,6 +1,6 @@
+import Config from '../../config';
 import { getYtcfgValue, isUserLoggedIn } from '../../utils';
 import { nativeJSONParse } from '../interceptors/natives';
-import Config from '../../config';
 import * as storage from '../storage';
 
 function getPlayer(payload, useAuth) {

--- a/src/components/endpoints/proxy.js
+++ b/src/components/endpoints/proxy.js
@@ -1,7 +1,7 @@
-import { isMusic, isEmbed } from '../../utils';
-import { nativeJSONParse } from '../interceptors/natives';
 import Config from '../../config';
+import { isEmbed, isMusic } from '../../utils';
 import * as logger from '../../utils/logger';
+import { nativeJSONParse } from '../interceptors/natives';
 
 let nextResponseCache = {};
 

--- a/src/components/errorScreen/index.js
+++ b/src/components/errorScreen/index.js
@@ -1,4 +1,4 @@
-import { waitForElement, createElement } from '../../utils';
+import { createElement, waitForElement } from '../../utils';
 import buttonTemplate from './templates/button.html';
 
 let buttons = {};

--- a/src/components/inspectors/index.js
+++ b/src/components/inspectors/index.js
@@ -1,4 +1,4 @@
-export * as player from './player';
-export * as next from './next';
 export * as googlevideo from './googlevideo';
+export * as next from './next';
+export * as player from './player';
 export * as search from './search';

--- a/src/components/inspectors/player.js
+++ b/src/components/inspectors/player.js
@@ -1,5 +1,5 @@
-import { isEmbed } from '../../utils';
 import Config from '../../config';
+import { isEmbed } from '../../utils';
 
 export function isPlayerObject(parsedData) {
     return parsedData?.videoDetails && parsedData?.playabilityStatus;
@@ -17,8 +17,8 @@ export function isAgeRestricted(playabilityStatus) {
     // Fix to detect age restrictions on embed player
     // see https://github.com/zerodytrash/Simple-YouTube-Age-Restriction-Bypass/issues/85#issuecomment-946853553
     return (
-        isEmbed &&
-        playabilityStatus.errorScreen?.playerErrorMessageRenderer?.reason?.runs?.find((x) => x.navigationEndpoint)?.navigationEndpoint?.urlEndpoint?.url?.includes('/2802167')
+        isEmbed
+        && playabilityStatus.errorScreen?.playerErrorMessageRenderer?.reason?.runs?.find((x) => x.navigationEndpoint)?.navigationEndpoint?.urlEndpoint?.url?.includes('/2802167')
     );
 }
 

--- a/src/components/inspectors/search.js
+++ b/src/components/inspectors/search.js
@@ -1,7 +1,7 @@
 export function isSearchResult(parsedData) {
     return (
-        typeof parsedData?.contents?.twoColumnSearchResultsRenderer === 'object' || // Desktop initial results
-        parsedData?.contents?.sectionListRenderer?.targetId === 'search-feed' || // Mobile initial results
-        parsedData?.onResponseReceivedCommands?.find((x) => x.appendContinuationItemsAction)?.appendContinuationItemsAction?.targetId === 'search-feed' // Desktop & Mobile scroll continuation
+        typeof parsedData?.contents?.twoColumnSearchResultsRenderer === 'object' // Desktop initial results
+        || parsedData?.contents?.sectionListRenderer?.targetId === 'search-feed' // Mobile initial results
+        || parsedData?.onResponseReceivedCommands?.find((x) => x.appendContinuationItemsAction)?.appendContinuationItemsAction?.targetId === 'search-feed' // Desktop & Mobile scroll continuation
     );
 }

--- a/src/components/interceptors/generic.js
+++ b/src/components/interceptors/generic.js
@@ -5,7 +5,7 @@ export default function attach(obj, prop, onCall) {
 
     let original = obj[prop];
 
-    obj[prop] = function () {
+    obj[prop] = function() {
         try {
             onCall(arguments);
         } catch {}

--- a/src/components/interceptors/json.js
+++ b/src/components/interceptors/json.js
@@ -1,9 +1,9 @@
-import { nativeJSONParse } from './natives';
 import { isObject } from '../../utils';
+import { nativeJSONParse } from './natives';
 
 // Intercept, inspect and modify JSON-based communication to unlock player responses by hijacking the JSON.parse function
 export default function attach(onJsonDataReceived) {
-    window.JSON.parse = function () {
+    window.JSON.parse = function() {
         const data = nativeJSONParse.apply(this, arguments);
         return isObject(data) ? onJsonDataReceived(data) : data;
     };

--- a/src/components/interceptors/xhrOpen.js
+++ b/src/components/interceptors/xhrOpen.js
@@ -1,9 +1,9 @@
-import { nativeXMLHttpRequestOpen } from './natives';
 import { parseRelativeUrl } from '../../utils';
 import * as logger from '../../utils/logger';
+import { nativeXMLHttpRequestOpen } from './natives';
 
 export default function attach(onXhrOpenCalled) {
-    XMLHttpRequest.prototype.open = function (method, url) {
+    XMLHttpRequest.prototype.open = function(method, url) {
         try {
             let parsedUrl = parseRelativeUrl(url);
 

--- a/src/components/requestPreprocessor.js
+++ b/src/components/requestPreprocessor.js
@@ -1,10 +1,10 @@
 import Config from '../config';
-import * as storage from './storage';
-import * as interceptors from './interceptors';
-import * as inspectors from './inspectors';
-import * as unlocker from './unlocker';
-import { proxy } from './endpoints';
 import { isObject } from '../utils';
+import { proxy } from './endpoints';
+import * as inspectors from './inspectors';
+import * as interceptors from './interceptors';
+import * as storage from './storage';
+import * as unlocker from './unlocker';
 
 /**
  *  Handles XMLHttpRequests and

--- a/src/components/strategies/index.js
+++ b/src/components/strategies/index.js
@@ -1,2 +1,2 @@
-export { default as getPlayerUnlockStrategies } from './player.js';
 export { default as getNextUnlockStrategies } from './next.js';
+export { default as getPlayerUnlockStrategies } from './player.js';

--- a/src/components/strategies/next.js
+++ b/src/components/strategies/next.js
@@ -1,5 +1,5 @@
-import { proxy, innertube } from '../endpoints';
-import { isEmbed, isConfirmed, getYtcfgValue } from '../../utils';
+import { getYtcfgValue, isConfirmed, isEmbed } from '../../utils';
+import { innertube, proxy } from '../endpoints';
 
 export default function getUnlockStrategies(videoId, lastPlayerUnlockReason) {
     const clientName = getYtcfgValue('INNERTUBE_CLIENT_NAME') || 'WEB';

--- a/src/components/strategies/player.js
+++ b/src/components/strategies/player.js
@@ -1,5 +1,5 @@
+import { getCurrentVideoStartTime, getSignatureTimestamp, getYtcfgValue, isConfirmed, isEmbed } from '../../utils';
 import { innertube, proxy } from '../endpoints';
-import { isEmbed, isConfirmed, getCurrentVideoStartTime, getYtcfgValue, getSignatureTimestamp } from '../../utils';
 
 export default function getUnlockStrategies(videoId, reason) {
     const clientName = getYtcfgValue('INNERTUBE_CLIENT_NAME') || 'WEB';

--- a/src/components/thumbnailFix.js
+++ b/src/components/thumbnailFix.js
@@ -1,6 +1,6 @@
+import Config from '../config';
 import { findNestedObjectsByAttributeNames } from '../utils';
 import * as logger from '../utils/logger';
-import Config from '../config';
 
 export function processThumbnails(responseObject) {
     const thumbnails = findNestedObjectsByAttributeNames(responseObject, ['url', 'height']).filter((x) => typeof x.url === 'string' && x.url.indexOf('https://i.ytimg.com/') === 0);

--- a/src/components/toast/index.js
+++ b/src/components/toast/index.js
@@ -1,5 +1,5 @@
-import { isDesktop, isMusic, isEmbed, pageLoaded, createElement } from '../../utils';
 import Config from '../../config';
+import { createElement, isDesktop, isEmbed, isMusic, pageLoaded } from '../../utils';
 
 import tDesktop from './templates/desktop.html';
 import tMobile from './templates/mobile.html';

--- a/src/components/unlocker/index.js
+++ b/src/components/unlocker/index.js
@@ -1,4 +1,4 @@
-export { default as unlockPlayerResponse } from './player.js';
 export { default as unlockNextResponse } from './next.js';
+export { default as unlockPlayerResponse } from './player.js';
 
-export { lastPlayerUnlockReason, lastPlayerUnlockVideoId, getLastProxiedGoogleVideoId } from './player.js';
+export { getLastProxiedGoogleVideoId, lastPlayerUnlockReason, lastPlayerUnlockVideoId } from './player.js';

--- a/src/components/unlocker/next.js
+++ b/src/components/unlocker/next.js
@@ -1,7 +1,7 @@
+import { createDeepCopy, isDesktop } from '../../utils';
 import * as logger from '../../utils/logger';
 import { next as nextInspector } from '../inspectors';
 import { getNextUnlockStrategies } from '../strategies';
-import { isDesktop, createDeepCopy } from '../../utils';
 import { lastPlayerUnlockReason, lastPlayerUnlockVideoId } from './player';
 
 let cachedNextResponse = {};
@@ -65,10 +65,10 @@ function mergeNextResponse(originalNextResponse, unlockedNextResponse) {
 
         // Transfer video description to original response
         const originalVideoSecondaryInfoRenderer = originalNextResponse.contents.twoColumnWatchNextResults.results.results.contents.find(
-            (x) => x.videoSecondaryInfoRenderer
+            (x) => x.videoSecondaryInfoRenderer,
         ).videoSecondaryInfoRenderer;
         const unlockedVideoSecondaryInfoRenderer = unlockedNextResponse.contents.twoColumnWatchNextResults.results.results.contents.find(
-            (x) => x.videoSecondaryInfoRenderer
+            (x) => x.videoSecondaryInfoRenderer,
         ).videoSecondaryInfoRenderer;
 
         if (unlockedVideoSecondaryInfoRenderer.description) originalVideoSecondaryInfoRenderer.description = unlockedVideoSecondaryInfoRenderer.description;
@@ -78,7 +78,7 @@ function mergeNextResponse(originalNextResponse, unlockedNextResponse) {
 
     // Transfer WatchNextResults to original response
     const unlockedWatchNextFeed = unlockedNextResponse.contents?.singleColumnWatchNextResults?.results?.results?.contents?.find(
-        (x) => x.itemSectionRenderer?.targetId === 'watch-next-feed'
+        (x) => x.itemSectionRenderer?.targetId === 'watch-next-feed',
     );
 
     if (unlockedWatchNextFeed) originalNextResponse.contents.singleColumnWatchNextResults.results.results.contents.push(unlockedWatchNextFeed);
@@ -91,6 +91,7 @@ function mergeNextResponse(originalNextResponse, unlockedNextResponse) {
         .find((x) => x.engagementPanelSectionListRenderer)
         .engagementPanelSectionListRenderer.content.structuredDescriptionContentRenderer.items.find((x) => x.expandableVideoDescriptionBodyRenderer);
 
-    if (unlockedStructuredDescriptionContentRenderer.expandableVideoDescriptionBodyRenderer)
+    if (unlockedStructuredDescriptionContentRenderer.expandableVideoDescriptionBodyRenderer) {
         originalStructuredDescriptionContentRenderer.expandableVideoDescriptionBodyRenderer = unlockedStructuredDescriptionContentRenderer.expandableVideoDescriptionBodyRenderer;
+    }
 }

--- a/src/components/unlocker/player.js
+++ b/src/components/unlocker/player.js
@@ -1,9 +1,9 @@
 import Config from '../../config';
-import * as logger from '../../utils/logger';
-import Toast from '../toast';
-import { getPlayerUnlockStrategies } from '../strategies';
 import { createDeepCopy, getYtcfgValue, isUserLoggedIn } from '../../utils';
+import * as logger from '../../utils/logger';
 import { isConfirmationRequired, requestConfirmation } from '../confirmation';
+import { getPlayerUnlockStrategies } from '../strategies';
+import Toast from '../toast';
 
 const messagesMap = {
     success: 'Age-restricted video successfully unlocked!',

--- a/src/config.js
+++ b/src/config.js
@@ -33,7 +33,7 @@ const THUMBNAIL_BLURRED_SQPS = [
     '-oaymwESCOADEOgC8quKqQMG7QGZmRlC', // Mobile 480x360
 ];
 
- // small hack to prevent tree shaking on these exports
+// small hack to prevent tree shaking on these exports
 export default window[Symbol()] = {
     UNLOCKABLE_PLAYABILITY_STATUSES,
     VALID_PLAYABILITY_STATUSES,

--- a/src/extension/main.js
+++ b/src/extension/main.js
@@ -70,7 +70,7 @@ function updateConfig(changes) {
     window.dispatchEvent(
         new CustomEvent('SYARB_CONFIG_CHANGE', {
             detail: newValue,
-        })
+        }),
     );
 }
 

--- a/src/extension/multi-page-menu.js
+++ b/src/extension/multi-page-menu.js
@@ -27,7 +27,7 @@ function transitionTo(event) {
             event.currentTarget.style.display = 'none';
             animating = false;
         },
-        { once: true }
+        { once: true },
     );
 
     if (!nPage.dataset.state || nPage.dataset.state === 'cold') {
@@ -50,6 +50,6 @@ function transitionTo(event) {
             detail: {
                 pageId: selector,
             },
-        })
+        }),
     );
 }

--- a/src/main.js
+++ b/src/main.js
@@ -1,9 +1,9 @@
 import './config';
-import * as interceptors from './components/interceptors';
 import * as inspectors from './components/inspectors';
-import * as unlocker from './components/unlocker';
-import * as thumbnailFix from './components/thumbnailFix';
+import * as interceptors from './components/interceptors';
 import * as requestPreprocessor from './components/requestPreprocessor';
+import * as thumbnailFix from './components/thumbnailFix';
+import * as unlocker from './components/unlocker';
 import * as logger from './utils/logger';
 
 try {
@@ -20,8 +20,7 @@ function processYtData(ytData) {
         // Player Unlock #1: Initial page data structure and response from `/youtubei/v1/player` XHR request
         if (inspectors.player.isPlayerObject(ytData) && inspectors.player.isAgeRestricted(ytData.playabilityStatus)) {
             unlocker.unlockPlayerResponse(ytData);
-        }
-        // Player Unlock #2: Embedded Player inital data structure
+        } // Player Unlock #2: Embedded Player inital data structure
         else if (inspectors.player.isEmbeddedPlayerObject(ytData) && inspectors.player.isAgeRestricted(ytData.previewPlayabilityStatus)) {
             unlocker.unlockPlayerResponse(ytData);
         }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -12,7 +12,7 @@ export class Deferred {
                 this.resolve = resolve;
                 this.reject = reject;
             }),
-            this
+            this,
         );
     }
 }
@@ -71,8 +71,8 @@ export function getYtcfgValue(name) {
 
 export function getSignatureTimestamp() {
     return (
-        getYtcfgValue('STS') ||
-        (() => {
+        getYtcfgValue('STS')
+        || (() => {
             // STS is missing on embedded player. Retrieve from player base script as fallback...
             const playerBaseJsPath = document.querySelector('script[src*="/base.js"]')?.src;
 

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -13,7 +13,7 @@ export function error(err, msg) {
                     message: (msg ? msg + '; ' : '') + (err && err.message ? err.message : ''),
                     stack: err && err.stack ? err.stack : null,
                 },
-            })
+            }),
         );
     }
 }
@@ -26,7 +26,7 @@ export function info(msg) {
                 detail: {
                     message: msg,
                 },
-            })
+            }),
         );
     }
 }
@@ -34,11 +34,11 @@ export function info(msg) {
 export function getYtcfgDebugString() {
     try {
         return (
-            `InnertubeConfig: ` +
-            `innertubeApiKey: ${getYtcfgValue('INNERTUBE_API_KEY')} ` +
-            `innertubeClientName: ${getYtcfgValue('INNERTUBE_CLIENT_NAME')} ` +
-            `innertubeClientVersion: ${getYtcfgValue('INNERTUBE_CLIENT_VERSION')} ` +
-            `loggedIn: ${getYtcfgValue('LOGGED_IN')} `
+            `InnertubeConfig: `
+            + `innertubeApiKey: ${getYtcfgValue('INNERTUBE_API_KEY')} `
+            + `innertubeClientName: ${getYtcfgValue('INNERTUBE_CLIENT_NAME')} `
+            + `innertubeClientVersion: ${getYtcfgValue('INNERTUBE_CLIENT_VERSION')} `
+            + `loggedIn: ${getYtcfgValue('LOGGED_IN')} `
         );
     } catch (err) {
         return `Failed to access config: ${err}`;


### PR DESCRIPTION
dprint (written in Rust) is much faster than Prettier by a long shot. Formatting the `user.js` in `dist` took ~\~400ms~ ~700ms with Prettier, now this only takes ~20ms.

I also find the formatting much better with dprint. It reorders all the imports unlike Prettier and some of the multi-line code is more readable.

Out of the box it formats TypeScript. Could come in handy if we decide to transition from JavaScript in the future.

This change will impact building, formatting and GitHub CI.