### PR TITLE
[fix] description not being set

### DIFF
--- a/src/components/unlocker/next.js
+++ b/src/components/unlocker/next.js
@@ -71,7 +71,11 @@ function mergeNextResponse(originalNextResponse, unlockedNextResponse) {
             (x) => x.videoSecondaryInfoRenderer
         ).videoSecondaryInfoRenderer;
 
-        if (unlockedVideoSecondaryInfoRenderer.description) originalVideoSecondaryInfoRenderer.description = unlockedVideoSecondaryInfoRenderer.description;
+        // TODO: Throw if description not found?
+        if (unlockedVideoSecondaryInfoRenderer.description)
+            originalVideoSecondaryInfoRenderer.description = unlockedVideoSecondaryInfoRenderer.description;
+        else if (unlockedVideoSecondaryInfoRenderer.attributedDescription)
+            originalVideoSecondaryInfoRenderer.attributedDescription = unlockedVideoSecondaryInfoRenderer.attributedDescription;
 
         return;
     }


### PR DESCRIPTION
Proxy returns `attributedDescription` instead of `description`.

"Improvise, adapt to the environment, Darwin, I Ching, whatever man, we gotta roll with it."

**Related issues**
- #159