### PR TITLE
[extension] use two stages of injection

### DIFF
--- a/src/extension/main.js
+++ b/src/extension/main.js
@@ -32,9 +32,8 @@ function injectScript() {
 
         const mainCode = `window.SYARB_CONFIG = ${JSON.stringify(options || {})};` + scriptContents;
 
-        const injectorCode =
         // DANGER: DO NOT USE GLOBALS HERE WITHOUT `window` OBJECT!! FIREFOX BUG WITH GLOBALS.
-        `
+        const injectorCode = `
         const nScript = document.createElement('script');
         nScript.innerHTML = ${JSON.stringify(mainCode)};
         document.documentElement.append(nScript);


### PR DESCRIPTION
The current injection method has an issue on Firefox where globals are not defined as they should be, leading to issues where `window.` has to be prefixed on all native functions, objects, etc.

Now injector stage 1 injects stage 2, which in turn injects the main script.

Stage 1: `onclick` event
Stage 2: `script` tag

~Hopefully this is just as fast as not to cause any race conditions.~

**EDIT:** Performance should be the same, maybe slightly better in FF. Stage 2 runs immediately after stage 1 (it's blocking).

**Related issues**
- #172