### PR TITLE
[chore] Add automated release pipeline

### DIFF
--- a/.github/scripts/publish_greasyfork.sh
+++ b/.github/scripts/publish_greasyfork.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+set -eu
+
+AUTH_TOKEN=""
+
+COOKIE_FILE_PATH="/tmp/cookies.txt"
+
+BASE_URL="https://greasyfork.org"
+# "/en/search" appears to be the lightest
+INITIAL_PAGE_PATH="/en/search"
+
+LOGIN_URL="$BASE_URL/en/users/sign_in?return_to=$INITIAL_PAGE_PATH"
+UPDATE_URL="$BASE_URL/en/scripts/$GREASYFORK_SCRIPT_ID/versions"
+INITIAL_URL="$BASE_URL$INITIAL_PAGE_PATH"
+
+case $GREASYFORK_SCRIPT_TYPE in
+    "public") GREASYFORK_SCRIPT_TYPE=1 ;;
+    "unlisted") GREASYFORK_SCRIPT_TYPE=2 ;;
+    "library") GREASYFORK_SCRIPT_TYPE=3 ;;
+esac
+
+request() {
+    curl -fsSL -b "$COOKIE_FILE_PATH" -c "$COOKIE_FILE_PATH" "$@"
+}
+
+extract_auth_token() {
+    awk -F '"' '/name="csrf-token"/{print $4}' <<< "$@"
+}
+
+cleanup() {
+    rm -f "$COOKIE_FILE_PATH"
+}
+
+trap cleanup EXIT
+
+# Get initial page to retrieve the initial auth token
+INITIAL_RESPONSE="$(request "$INITIAL_URL")"
+AUTH_TOKEN="$(extract_auth_token "$INITIAL_RESPONSE")"
+
+# Log in to retrieve the final login auth token
+LOGIN_RESPONSE="$(request \
+    -d "authenticity_token=$AUTH_TOKEN" \
+    -d "user[email]=$GREASYFORK_USER_EMAIL" \
+    -d "user[password]=$GREASYFORK_USER_PASS" \
+    -d "user[remember_me]=0" \
+    -d "commit=Log in" \
+    "$LOGIN_URL")"
+
+# Check if login was successful
+if [[ "$LOGIN_RESPONSE" != *"Sign out"* ]]; then
+    echo -e "\e[38;2;103;103;103m$LOGIN_RESPONSE\e[0m\n"
+    echo -e "\e[1;31mFailed: Sign in\e[0m - Unknown reason"
+    exit 1
+fi
+
+# Extract updated authenticity token after successful login
+AUTH_TOKEN="$(extract_auth_token "$LOGIN_RESPONSE")"
+
+# Update the script
+SCRIPT_FILE_PATH="$(find . -iwholename "$SCRIPT_FILE_PATH" -print -quit)"
+SCRIPT_UPDATE_RESPONSE="$(request \
+    -F "authenticity_token=$AUTH_TOKEN" \
+    -F "script_version[code]=" \
+    -F "code_upload=@$SCRIPT_FILE_PATH" \
+    -F "script_version[attachments][]=" \
+    -F "script_version[attachments][]=; filename=\"\"" \
+    -F "script_version[additional_info][0][attribute_default]=true" \
+    -F "script_version[additional_info][0][value_markup]=html" \
+    -F "script_version[additional_info][0][attribute_value]=" \
+    -F "script_version[changelog_markup]=html" \
+    -F "script_version[changelog]=" \
+    -F "script[script_type_id]=$GREASYFORK_SCRIPT_TYPE" \
+    -F "script[adult_content_self_report]=0" \
+    -F "commit=Post new version" \
+    "$UPDATE_URL")"
+
+# Check if the script update was successful
+if [[ "$SCRIPT_UPDATE_RESPONSE" != *"id=\"install-area\""* ]]; then
+    echo -e "\e[38;2;103;103;103m$SCRIPT_UPDATE_RESPONSE\e[0m\n"
+    if [[ "$SCRIPT_UPDATE_RESPONSE" == *"validation-errors"* ]]; then
+        echo -e "\e[1;31mFailed: Publish to GreasyFork\e[0m - Validation errors were reported"
+    else
+        echo -e "\e[1;31mFailed: Publish to GreasyFork\e[0m - Unknown reason"
+    fi
+    exit 1
+fi

--- a/.github/workflows/release_and_publish.yml
+++ b/.github/workflows/release_and_publish.yml
@@ -1,0 +1,80 @@
+name: Release and publish
+run-name: Release and publish ${{ github.event.release.tag_name }}
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+concurrency: ${{ github.workflow }}
+
+env:
+  TAG_NAME: ${{ github.event.release.tag_name }}
+  USERSCRIPT_FILE_PATH: dist/Simple-YouTube-Age-Restriction-Bypass.user.js
+
+jobs:
+  release_and_publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.release.target_commitish }}
+          fetch-depth: 0
+
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: lts/*
+
+      - name: Update package version
+        run: |
+          npm version "$TAG_NAME" --allow-same-version --git-tag-version false
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Commit changes
+        env:
+          COMMIT_USER_NAME: github-actions[bot]
+          COMMIT_USER_EMAIL: github-actions[bot]@users.noreply.github.com
+          COMMIT_AUTHOR: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
+          COMMIT_MESSAGE: Release ${{ env.TAG_NAME }}
+          COMMIT_FILES: |
+            ${{ env.USERSCRIPT_FILE_PATH }}
+            *.json
+        run: |
+          git config user.name "$COMMIT_USER_NAME"
+          git config user.email "$COMMIT_USER_EMAIL"
+          git add -f $(echo "$COMMIT_FILES")
+          git commit -m "$COMMIT_MESSAGE" --author="$COMMIT_AUTHOR"
+          git push origin
+
+      - name: Update tag
+        run: |
+          git tag -f "$TAG_NAME"
+          git push -f origin "$TAG_NAME"
+
+      - name: Release on Github
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            ${{ env.USERSCRIPT_FILE_PATH }}
+            dist/**/*.zip
+
+      - name: Publish on GreasyFork
+        env:
+          GREASYFORK_USER_EMAIL: ${{ secrets.GREASYFORK_USER_EMAIL }}
+          GREASYFORK_USER_PASS: ${{ secrets.GREASYFORK_USER_PASS }}
+          GREASYFORK_SCRIPT_ID: "423851"
+          # public - for all to see and use.
+          # unlisted - for (semi-)private use. Available by direct access, but not linked to from anywhere on Greasy Fork.
+          # library - intended to be @require-d from other scripts and not installed directly.
+          GREASYFORK_SCRIPT_TYPE: public
+          SCRIPT_FILE_PATH: ./${{ env.USERSCRIPT_FILE_PATH }}
+        run: bash ./.github/scripts/publish_greasyfork.sh


### PR DESCRIPTION
This PR introduces a new workflow for releasing and publishing on GitHub and GreasyFork. The workflow is triggered whenever a new GitHub release is published.

**Automation Overview**
This workflow automates the process of changing the package.json version number to match the release tag. It then builds and commits the latest release and automatically uploads the latest assets along with the GitHub release. Finally, the updated script is published on GreasyFork.

### Tasks
- [x] Implement GitHub release
- [x] Add support for GreasyFork
- [ ] ~Add support for OpenUserJS~