### PR TITLE
[fix] video `startTimeSecs` ignored with proxy

### DIFF
--- a/src/components/unlocker/player.js
+++ b/src/components/unlocker/player.js
@@ -97,21 +97,37 @@ function getUnlockedPlayerResponse(videoId, reason) {
 
         const isStatusValid = Config.VALID_PLAYABILITY_STATUSES.includes(unlockedPlayerResponse?.playabilityStatus?.status);
 
-        /**
-         * Workaround: https://github.com/zerodytrash/Simple-YouTube-Age-Restriction-Bypass/issues/191
-         *
-         * YouTube checks if the `trackingParams` in the response matches the decoded `trackingParam` in `responseContext.mainAppWebResponseContext`.
-         * However, sometimes the response does not include the `trackingParam` in the `responseContext`, causing the check to fail.
-         *
-         * This workaround addresses the issue by hardcoding the `trackingParams` in the response context.
-         */
-        if (isStatusValid && !unlockedPlayerResponse.trackingParams || !unlockedPlayerResponse.responseContext?.mainAppWebResponseContext?.trackingParam) {
-            unlockedPlayerResponse.trackingParams = 'CAAQu2kiEwjor8uHyOL_AhWOvd4KHavXCKw=';
-            unlockedPlayerResponse.responseContext = {
-                mainAppWebResponseContext: {
-                    trackingParam: 'kx_fmPxhoPZRzgL8kzOwANUdQh8ZwHTREkw2UqmBAwpBYrzRgkuMsNLBwOcCE59TDtslLKPQ-SS',
-                },
-            };
+        if (isStatusValid) {
+
+            /**
+             * Workaround: https://github.com/zerodytrash/Simple-YouTube-Age-Restriction-Bypass/issues/191
+             *
+             * YouTube checks if the `trackingParams` in the response matches the decoded `trackingParam` in `responseContext.mainAppWebResponseContext`.
+             * However, sometimes the response does not include the `trackingParam` in the `responseContext`, causing the check to fail.
+             *
+             * This workaround addresses the issue by hardcoding the `trackingParams` in the response context.
+             */
+            if (!unlockedPlayerResponse.trackingParams || !unlockedPlayerResponse.responseContext?.mainAppWebResponseContext?.trackingParam) {
+                unlockedPlayerResponse.trackingParams = 'CAAQu2kiEwjor8uHyOL_AhWOvd4KHavXCKw=';
+                unlockedPlayerResponse.responseContext = {
+                    mainAppWebResponseContext: {
+                        trackingParam: 'kx_fmPxhoPZRzgL8kzOwANUdQh8ZwHTREkw2UqmBAwpBYrzRgkuMsNLBwOcCE59TDtslLKPQ-SS',
+                    },
+                };
+            }
+
+            /**
+             * Workaround: Account proxy response currently does not include `playerConfig`
+             *
+             * Stays here until we rewrite the account proxy to only include the necessary and bare minimum response
+             */
+            if (strategy.payload.startTimeSecs && strategy.name === 'Account Proxy') {
+                unlockedPlayerResponse.playerConfig = {
+                    playbackStartConfig: {
+                        startSeconds: strategy.payload.startTimeSecs,
+                    }
+                }
+            }
         }
 
         return !isStatusValid;

--- a/src/components/unlocker/player.js
+++ b/src/components/unlocker/player.js
@@ -98,7 +98,6 @@ function getUnlockedPlayerResponse(videoId, reason) {
         const isStatusValid = Config.VALID_PLAYABILITY_STATUSES.includes(unlockedPlayerResponse?.playabilityStatus?.status);
 
         if (isStatusValid) {
-
             /**
              * Workaround: https://github.com/zerodytrash/Simple-YouTube-Age-Restriction-Bypass/issues/191
              *
@@ -125,8 +124,8 @@ function getUnlockedPlayerResponse(videoId, reason) {
                 unlockedPlayerResponse.playerConfig = {
                     playbackStartConfig: {
                         startSeconds: strategy.payload.startTimeSecs,
-                    }
-                }
+                    },
+                };
             }
         }
 


### PR DESCRIPTION
Account proxy response currently does not include `playerConfig`.

Until we rewrite the account proxy to only include the necessary and bare minimum response, this will be fixed in the client only. I don't want to take the risk of somehow breaking it as the current proxy codebase IMO is a mess.