### PR TITLE
docs(readme): replace bromite with cromite

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ And many more!
 **Simple YouTube Age Restriction Bypass** works on Android with the browser version of YouTube [m.youtube.com](https://m.youtube.com) in combination with the [Userscript](#userscript).
 > Only a few browsers such as [Firefox](https://play.google.com/store/apps/details?id=org.mozilla.firefox) and [Kiwi Browser](https://play.google.com/store/apps/details?id=com.kiwibrowser.browser) currently support extensions. Tampermonkey can be installed there.
 
-> [Bromite](https://www.bromite.org/) supports userscripts natively. The script can be installed via Settings > User Scripts.
+> [Cromite](https://www.cromite.org/) supports userscripts natively. The script can be installed via Settings > User Scripts.
 
 ### iOS/iPadOS
 


### PR DESCRIPTION
Bromite is no longer maintained and therefore it shouldn't be advised to use it. Cromite is an updated fork which also supports userscripts.